### PR TITLE
Fixes for matplotlib backend and use patch collection in colored draw

### DIFF
--- a/hexalattice/hexalattice.py
+++ b/hexalattice/hexalattice.py
@@ -14,7 +14,6 @@ import matplotlib.patches as mpatches
 from matplotlib.collections import PatchCollection
 from typing import List, Union
 import matplotlib
-matplotlib.use('Qt5Agg')
 
 
 def create_hex_grid(nx: int = 4,
@@ -145,11 +144,15 @@ def plot_single_lattice(coord_x, coord_y, face_color, edge_color, min_diam, plot
 
     if background_color is not None:
         h_ax.set_facecolor(background_color)
+        
+    radius = radius=min_diam / np.sqrt(3) * (1 - plotting_gap)
+    orientation = np.deg2rad(-rotate_deg)
+    
     patches = []
     for curr_x, curr_y in zip(coord_x, coord_y):
         polygon = mpatches.RegularPolygon((curr_x, curr_y), numVertices=6,
-                                          radius=min_diam / np.sqrt(3) * (1 - plotting_gap),
-                                          orientation=np.deg2rad(-rotate_deg))
+                                          radius=radius,
+                                          orientation=orientation)
         patches.append(polygon)
     collection = PatchCollection(patches, edgecolor=edge_color, facecolor=face_color, linewidths=line_width)
     h_ax.add_collection(collection)
@@ -234,13 +237,23 @@ def plot_single_lattice_custom_colors(coord_x, coord_y, face_color, edge_color, 
         if background_color is not None:
             h_ax.set_facecolor(background_color)
 
-    for i, (curr_x, curr_y) in enumerate(zip(coord_x, coord_y)):
+    radius = min_diam / np.sqrt(3) * (1 - plotting_gap)
+    orientation = np.deg2rad(-rotate_deg)
+
+    polygons = []
+
+    for curr_x, curr_y in zip(coord_x, coord_y):
         polygon = mpatches.RegularPolygon((curr_x, curr_y), numVertices=6,
-                                          radius=min_diam / np.sqrt(3) * (1 - plotting_gap),
-                                          orientation=np.deg2rad(-rotate_deg),
-                                          edgecolor=edge_color[i],
-                                          facecolor=face_color[i], linewidth=line_width)
-        h_ax.add_artist(polygon)
+                                          radius=radius,
+                                          orientation=orientation)
+        polygons.append(polygon)
+
+    h_ax.add_artist(
+        PatchCollection(
+            patches=polygons,
+            facecolors=face_color,
+            edgecolors=edge_color,
+            linewidth=line_width))
 
     h_ax.set_aspect('equal')
     h_ax.axis([coord_x.min() - 2 * min_diam, coord_x.max() + 2 * min_diam, coord_y.min() - 2 * min_diam,
@@ -272,7 +285,7 @@ def sample_colors_from_image_by_grid(image_path: str, x_coords, y_coords):
 
 
 def main():
-
+    matplotlib.use('Qt5Agg')
     plt.ion()
 
     # (1) === Create single hexagonal 5*5 lattice and plot it. Extract the [x,y] locations of the tile centers


### PR DESCRIPTION
Hey 👋 

Really love this library, helped me a lot!

However, I was not able to use the library without changes, due to the Matplotlib backend being set inside the library, which was not an option for my project.

IMHO, the library should not set the backend, but the user.

I modified the code, so that, the example sets the backend.
Now the library can be imported and used without problems in environments which are not able to use the backend.


Also, I had performance issues with bigger hexagonal grids.
This pull request also includes a refactoring for the custom colors plot, which now also utilizes patch collections, resulting in a great speed up for big colored hexagonal grids.

I executed your examples locally, and they all were still working.

Really hope this helps! If there are any issues, please let me know!