### PR TITLE
Add option to plot circles on the hex grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ conda install -c conda-forge hexalattice
 
 ## Usage example
 
-Create and plot 5x5 lattice of hexagons (as in first image):
+Create and plot 5x5 lattice of hexagons (as in first image) or circles on a hexagonal lattice:
 ```sh
 from hexalattice.hexalattice import *
 hex_centers, _ = create_hex_grid(nx=5,
-                                 ny=5,
+                                 ny=5, # shape="circle", # uncomment to plot circles
                                  do_plot=True)
                                  
 plt.show()    # import matplotlib.pyplot as plt

--- a/hexalattice/hexalattice.py
+++ b/hexalattice/hexalattice.py
@@ -418,6 +418,11 @@ def main():
                                       line_width=0.1,
                                       h_ax=axs[1, 1])
 
+    # (6) === Create single hexagonal 5*5 lattice but plot circles on it. Extract the [x,y] locations of the tile centers
+    hex_centers, h_ax = create_hex_grid(nx=5, ny=5, do_plot=True, shape="circle")
+    tile_centers_x = hex_centers[:, 0]
+    tile_centers_y = hex_centers[:, 1]
+
     plt.show(block=True)
 
 


### PR DESCRIPTION
I have added the keyword 'shape' to the two functions used for plotting hexagons. The default value is set to 'hexagon,' ensuring backward compatibility with existing code. When 'shape' is set to 'circle,' the code plots circles at the positions where hexagons were previously plotted. Within the 'circle' switch blocks, the radius is recalculated to accommodate circles. The apple example works equally well for the circle shape.

I have also included the 'shape' parameter in the 'check_inputs' function, following your coding style.

The minor modification to the README.md file includes a comment that informs users about the availability of the 'shape' keyword.

I believe this small addition enhances the project's value, as it now allows me to create brilliant schematics for my research project. Thank you for creating and maintaining the package